### PR TITLE
Fix/login progress and 2fa

### DIFF
--- a/src/garmy/localdb/progress.py
+++ b/src/garmy/localdb/progress.py
@@ -56,7 +56,11 @@ class ProgressReporter:
     def info(self, message: str):
         """Log info message."""
         self.logger.info(message)
-    
+
+    def warning(self, message: str):
+        """Log warning message."""
+        self.logger.warning(message)
+
     def error(self, message: str):
         """Log error message."""
         self.logger.error(message)

--- a/src/garmy/localdb/sync.py
+++ b/src/garmy/localdb/sync.py
@@ -43,7 +43,12 @@ class SyncManager:
             from garmy import AuthClient, APIClient
 
             auth_client = AuthClient()
-            auth_client.login(email, password)
+            auth_client.login(
+                email,
+                password,
+                prompt_mfa=lambda: input("MFA code: "),
+            )
+
             self.api_client = APIClient(auth_client=auth_client)
 
             self.activities_iterator = ActivitiesIterator(


### PR DESCRIPTION
Fix error for:
`Failed to initialize: 'ProgressReporter' object has no attribute 'warning'
Error: 'ProgressReporter' object has no attribute 'warning'`

And a silent failure during login when the account has 2FA enabled:
`Password:
Connecting to Garmin Connect...
Endpoint shared by multiple metrics: /wellness-service/wellness/dailyStress/{date} used by stress and body_battery
Failed to load activities batch at offset 0: Authentication required for fetching Activities: Not authenticated. Please login first.`